### PR TITLE
Fix inconsistent namespace warning

### DIFF
--- a/hector_xacro_tools/urdf/inertia_tensors.urdf.xacro
+++ b/hector_xacro_tools/urdf/inertia_tensors.urdf.xacro
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://ros.org/wiki/xacro">
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
   <xacro:macro name="inertial_cuboid" params="mass x_length y_length z_length">
     <inertial>


### PR DESCRIPTION
Most of files define url with perciding www. Lack of it results in warning

inconsistent namespace redefinitions for xmlns:xacro:
 old: http://www.ros.org/wiki/xacro
 new: http://ros.org/wiki/xacro 